### PR TITLE
feat: Add methods to retrieve closed and cancelled orders by trade ID in SubgraphClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 *.pyc
 
 .DS_Store
+
+venv/

--- a/ostium_python_sdk/abi/trading_abi.py
+++ b/ostium_python_sdk/abi/trading_abi.py
@@ -1,1972 +1,2217 @@
 trading_abi = [
-    {
-        "inputs": [],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "inputs": [],
-        "name": "AboveMaxAllowedCollateral",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            }
-        ],
-        "name": "AlreadyMarketClosed",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "BelowFees",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "BelowMinLevPos",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "DelegatedActionFailed",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "ExposureLimits",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "InvalidInitialization",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "a",
-                "type": "address"
-            }
-        ],
-        "name": "IsContract",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "IsDone",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "IsPaused",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "MathOverflowedMulDiv",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            }
-        ],
-        "name": "MaxPendingMarketOrdersReached",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            }
-        ],
-        "name": "MaxTradesPerPairReached",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "a",
-                "type": "address"
-            }
-        ],
-        "name": "NoDelegate",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            }
-        ],
-        "name": "NoLimitFound",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            }
-        ],
-        "name": "NoTradeFound",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            }
-        ],
-        "name": "NoTradeToTimeoutFound",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            }
-        ],
-        "name": "NotCloseMarketTimeoutOrder",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "caller",
-                "type": "address"
-            }
-        ],
-        "name": "NotDelegate",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "a",
-                "type": "address"
-            }
-        ],
-        "name": "NotGov",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "NotInitializing",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "a",
-                "type": "address"
-            }
-        ],
-        "name": "NotManager",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            }
-        ],
-        "name": "NotOpenMarketTimeoutOrder",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "a",
-                "type": "address"
-            }
-        ],
-        "name": "NotTradesUpKeep",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            }
-        ],
-        "name": "NotYourOrder",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "NullAddr",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint16",
-                "name": "index",
-                "type": "uint16"
-            }
-        ],
-        "name": "PairNotListed",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint8",
-                "name": "bits",
-                "type": "uint8"
-            },
-            {
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "SafeCastOverflowedUintDowncast",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            }
-        ],
-        "name": "TriggerPending",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            }
-        ],
-        "name": "WaitTimeout",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint32",
-                "name": "leverage",
-                "type": "uint32"
-            }
-        ],
-        "name": "WrongLeverage",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "WrongParams",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "WrongSL",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "WrongTP",
-        "type": "error"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "enum IOstiumTradingStorage.LimitOrder",
-                "name": "",
-                "type": "uint8"
-            }
-        ],
-        "name": "AutomationCloseOrderInitiated",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            }
-        ],
-        "name": "AutomationOpenOrderInitiated",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "delegator",
-                "type": "address"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "delegate",
-                "type": "address"
-            }
-        ],
-        "name": "DelegateAdded",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "delegator",
-                "type": "address"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "delegate",
-                "type": "address"
-            }
-        ],
-        "name": "DelegateRemoved",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": False,
-                "internalType": "bool",
-                "name": "done",
-                "type": "bool"
-            }
-        ],
-        "name": "Done",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": False,
-                "internalType": "uint64",
-                "name": "version",
-                "type": "uint64"
-            }
-        ],
-        "name": "Initialized",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            }
-        ],
-        "name": "MarketCloseFailed",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            }
-        ],
-        "name": "MarketCloseOrderInitiated",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint16",
-                "name": "closePercentage",
-                "type": "uint16"
-            }
-        ],
-        "name": "MarketCloseOrderInitiatedV2",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "block",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint192",
-                        "name": "wantedPrice",
-                        "type": "uint192"
-                    },
-                    {
-                        "internalType": "uint32",
-                        "name": "slippageP",
-                        "type": "uint32"
-                    },
-                    {
-                        "components": [
-                            {
-                                "internalType": "uint256",
-                                "name": "collateral",
-                                "type": "uint256"
-                            },
-                            {
-                                "internalType": "uint192",
-                                "name": "openPrice",
-                                "type": "uint192"
-                            },
-                            {
-                                "internalType": "uint192",
-                                "name": "tp",
-                                "type": "uint192"
-                            },
-                            {
-                                "internalType": "uint192",
-                                "name": "sl",
-                                "type": "uint192"
-                            },
-                            {
-                                "internalType": "address",
-                                "name": "trader",
-                                "type": "address"
-                            },
-                            {
-                                "internalType": "uint32",
-                                "name": "leverage",
-                                "type": "uint32"
-                            },
-                            {
-                                "internalType": "uint16",
-                                "name": "pairIndex",
-                                "type": "uint16"
-                            },
-                            {
-                                "internalType": "uint8",
-                                "name": "index",
-                                "type": "uint8"
-                            },
-                            {
-                                "internalType": "bool",
-                                "name": "buy",
-                                "type": "bool"
-                            }
-                        ],
-                        "internalType": "struct IOstiumTradingStorage.Trade",
-                        "name": "trade",
-                        "type": "tuple"
-                    }
-                ],
-                "indexed": False,
-                "internalType": "struct IOstiumTradingStorage.PendingMarketOrder",
-                "name": "order",
-                "type": "tuple"
-            }
-        ],
-        "name": "MarketCloseTimeoutExecuted",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "block",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint192",
-                        "name": "wantedPrice",
-                        "type": "uint192"
-                    },
-                    {
-                        "internalType": "uint32",
-                        "name": "slippageP",
-                        "type": "uint32"
-                    },
-                    {
-                        "components": [
-                            {
-                                "internalType": "uint256",
-                                "name": "collateral",
-                                "type": "uint256"
-                            },
-                            {
-                                "internalType": "uint192",
-                                "name": "openPrice",
-                                "type": "uint192"
-                            },
-                            {
-                                "internalType": "uint192",
-                                "name": "tp",
-                                "type": "uint192"
-                            },
-                            {
-                                "internalType": "uint192",
-                                "name": "sl",
-                                "type": "uint192"
-                            },
-                            {
-                                "internalType": "address",
-                                "name": "trader",
-                                "type": "address"
-                            },
-                            {
-                                "internalType": "uint32",
-                                "name": "leverage",
-                                "type": "uint32"
-                            },
-                            {
-                                "internalType": "uint16",
-                                "name": "pairIndex",
-                                "type": "uint16"
-                            },
-                            {
-                                "internalType": "uint8",
-                                "name": "index",
-                                "type": "uint8"
-                            },
-                            {
-                                "internalType": "bool",
-                                "name": "buy",
-                                "type": "bool"
-                            }
-                        ],
-                        "internalType": "struct IOstiumTradingStorage.Trade",
-                        "name": "trade",
-                        "type": "tuple"
-                    },
-                    {
-                        "internalType": "uint16",
-                        "name": "percentage",
-                        "type": "uint16"
-                    }
-                ],
-                "indexed": False,
-                "internalType": "struct IOstiumTradingStorage.PendingMarketOrderV2",
-                "name": "order",
-                "type": "tuple"
-            }
-        ],
-        "name": "MarketCloseTimeoutExecutedV2",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            }
-        ],
-        "name": "MarketOpenOrderInitiated",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "block",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint192",
-                        "name": "wantedPrice",
-                        "type": "uint192"
-                    },
-                    {
-                        "internalType": "uint32",
-                        "name": "slippageP",
-                        "type": "uint32"
-                    },
-                    {
-                        "components": [
-                            {
-                                "internalType": "uint256",
-                                "name": "collateral",
-                                "type": "uint256"
-                            },
-                            {
-                                "internalType": "uint192",
-                                "name": "openPrice",
-                                "type": "uint192"
-                            },
-                            {
-                                "internalType": "uint192",
-                                "name": "tp",
-                                "type": "uint192"
-                            },
-                            {
-                                "internalType": "uint192",
-                                "name": "sl",
-                                "type": "uint192"
-                            },
-                            {
-                                "internalType": "address",
-                                "name": "trader",
-                                "type": "address"
-                            },
-                            {
-                                "internalType": "uint32",
-                                "name": "leverage",
-                                "type": "uint32"
-                            },
-                            {
-                                "internalType": "uint16",
-                                "name": "pairIndex",
-                                "type": "uint16"
-                            },
-                            {
-                                "internalType": "uint8",
-                                "name": "index",
-                                "type": "uint8"
-                            },
-                            {
-                                "internalType": "bool",
-                                "name": "buy",
-                                "type": "bool"
-                            }
-                        ],
-                        "internalType": "struct IOstiumTradingStorage.Trade",
-                        "name": "trade",
-                        "type": "tuple"
-                    }
-                ],
-                "indexed": False,
-                "internalType": "struct IOstiumTradingStorage.PendingMarketOrder",
-                "name": "order",
-                "type": "tuple"
-            }
-        ],
-        "name": "MarketOpenTimeoutExecuted",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "block",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint192",
-                        "name": "wantedPrice",
-                        "type": "uint192"
-                    },
-                    {
-                        "internalType": "uint32",
-                        "name": "slippageP",
-                        "type": "uint32"
-                    },
-                    {
-                        "components": [
-                            {
-                                "internalType": "uint256",
-                                "name": "collateral",
-                                "type": "uint256"
-                            },
-                            {
-                                "internalType": "uint192",
-                                "name": "openPrice",
-                                "type": "uint192"
-                            },
-                            {
-                                "internalType": "uint192",
-                                "name": "tp",
-                                "type": "uint192"
-                            },
-                            {
-                                "internalType": "uint192",
-                                "name": "sl",
-                                "type": "uint192"
-                            },
-                            {
-                                "internalType": "address",
-                                "name": "trader",
-                                "type": "address"
-                            },
-                            {
-                                "internalType": "uint32",
-                                "name": "leverage",
-                                "type": "uint32"
-                            },
-                            {
-                                "internalType": "uint16",
-                                "name": "pairIndex",
-                                "type": "uint16"
-                            },
-                            {
-                                "internalType": "uint8",
-                                "name": "index",
-                                "type": "uint8"
-                            },
-                            {
-                                "internalType": "bool",
-                                "name": "buy",
-                                "type": "bool"
-                            }
-                        ],
-                        "internalType": "struct IOstiumTradingStorage.Trade",
-                        "name": "trade",
-                        "type": "tuple"
-                    },
-                    {
-                        "internalType": "uint16",
-                        "name": "percentage",
-                        "type": "uint16"
-                    }
-                ],
-                "indexed": False,
-                "internalType": "struct IOstiumTradingStorage.PendingMarketOrderV2",
-                "name": "order",
-                "type": "tuple"
-            }
-        ],
-        "name": "MarketOpenTimeoutExecutedV2",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": False,
-                "internalType": "uint16",
-                "name": "value",
-                "type": "uint16"
-            }
-        ],
-        "name": "MarketOrdersTimeoutUpdated",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": False,
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "MaxAllowedCollateralUpdated",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            }
-        ],
-        "name": "OpenLimitCanceled",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            }
-        ],
-        "name": "OpenLimitPlaced",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint192",
-                "name": "newPrice",
-                "type": "uint192"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint192",
-                "name": "newTp",
-                "type": "uint192"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint192",
-                "name": "newSl",
-                "type": "uint192"
-            }
-        ],
-        "name": "OpenLimitUpdated",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "OracleFeeCharged",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "OracleFeeChargedLimitCancelled",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "OracleFeeRefunded",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": False,
-                "internalType": "bool",
-                "name": "paused",
-                "type": "bool"
-            }
-        ],
-        "name": "Paused",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint256",
-                "name": "removeAmount",
-                "type": "uint256"
-            }
-        ],
-        "name": "RemoveCollateralInitiated",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "orderId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint256",
-                "name": "removeAmount",
-                "type": "uint256"
-            },
-            {
-                "indexed": False,
-                "internalType": "string",
-                "name": "reason",
-                "type": "string"
-            }
-        ],
-        "name": "RemoveCollateralRejected",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint192",
-                "name": "newSl",
-                "type": "uint192"
-            }
-        ],
-        "name": "SlUpdated",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint256",
-                "name": "topUpAmount",
-                "type": "uint256"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint32",
-                "name": "newLeverage",
-                "type": "uint32"
-            }
-        ],
-        "name": "TopUpCollateralExecuted",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": True,
-                "internalType": "uint256",
-                "name": "tradeId",
-                "type": "uint256"
-            },
-            {
-                "indexed": True,
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "indexed": True,
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            },
-            {
-                "indexed": False,
-                "internalType": "uint192",
-                "name": "newTp",
-                "type": "uint192"
-            }
-        ],
-        "name": "TpUpdated",
-        "type": "event"
-    },
-    {
-        "anonymous": False,
-        "inputs": [
-            {
-                "indexed": False,
-                "internalType": "uint16",
-                "name": "value",
-                "type": "uint16"
-            }
-        ],
-        "name": "TriggerTimeoutUpdated",
-        "type": "event"
-    },
-    {
-        "inputs": [],
-        "name": "_msgSender",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            }
-        ],
-        "name": "cancelOpenLimitOrder",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            },
-            {
-                "internalType": "uint16",
-                "name": "closePercentage",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint192",
-                "name": "marketPrice",
-                "type": "uint192"
-            },
-            {
-                "internalType": "uint32",
-                "name": "slippageP",
-                "type": "uint32"
-            }
-        ],
-        "name": "closeTradeMarket",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_order",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bool",
-                "name": "retry",
-                "type": "bool"
-            }
-        ],
-        "name": "closeTradeMarketTimeout",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "internalType": "bytes",
-                "name": "call_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "delegatedAction",
-        "outputs": [
-            {
-                "internalType": "bytes",
-                "name": "",
-                "type": "bytes"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "delegator",
-                "type": "address"
-            }
-        ],
-        "name": "delegations",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "done",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "enum IOstiumTradingStorage.LimitOrder",
-                "name": "orderType",
-                "type": "uint8"
-            },
-            {
-                "internalType": "address",
-                "name": "trader",
-                "type": "address"
-            },
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            },
-            {
-                "internalType": "uint256",
-                "name": "priceTimestamp",
-                "type": "uint256"
-            }
-        ],
-        "name": "executeAutomationOrder",
-        "outputs": [
-            {
-                "internalType": "enum IOstiumTrading.AutomationOrderStatus",
-                "name": "",
-                "type": "uint8"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "contract IOstiumRegistry",
-                "name": "_registry",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_maxAllowedCollateral",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint16",
-                "name": "_marketOrdersTimeout",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint16",
-                "name": "_triggerTimeout",
-                "type": "uint16"
-            }
-        ],
-        "name": "initialize",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "isDone",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "isPaused",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "marketOrdersTimeout",
-        "outputs": [
-            {
-                "internalType": "uint16",
-                "name": "",
-                "type": "uint16"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "maxAllowedCollateral",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "components": [
-                    {
-                        "internalType": "uint256",
-                        "name": "collateral",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint192",
-                        "name": "openPrice",
-                        "type": "uint192"
-                    },
-                    {
-                        "internalType": "uint192",
-                        "name": "tp",
-                        "type": "uint192"
-                    },
-                    {
-                        "internalType": "uint192",
-                        "name": "sl",
-                        "type": "uint192"
-                    },
-                    {
-                        "internalType": "address",
-                        "name": "trader",
-                        "type": "address"
-                    },
-                    {
-                        "internalType": "uint32",
-                        "name": "leverage",
-                        "type": "uint32"
-                    },
-                    {
-                        "internalType": "uint16",
-                        "name": "pairIndex",
-                        "type": "uint16"
-                    },
-                    {
-                        "internalType": "uint8",
-                        "name": "index",
-                        "type": "uint8"
-                    },
-                    {
-                        "internalType": "bool",
-                        "name": "buy",
-                        "type": "bool"
-                    }
-                ],
-                "internalType": "struct IOstiumTradingStorage.Trade",
-                "name": "t",
-                "type": "tuple"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "address",
-                        "name": "builder",
-                        "type": "address"
-                    },
-                    {
-                        "internalType": "uint32",
-                        "name": "builderFee",
-                        "type": "uint32"
-                    }
-                ],
-                "internalType": "struct IOstiumTradingStorage.BuilderFee",
-                "name": "bf",
-                "type": "tuple"
-            },
-            {
-                "internalType": "enum IOstiumTradingStorage.OpenOrderType",
-                "name": "orderType",
-                "type": "uint8"
-            },
-            {
-                "internalType": "uint256",
-                "name": "slippageP",
-                "type": "uint256"
-            }
-        ],
-        "name": "openTrade",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_order",
-                "type": "uint256"
-            }
-        ],
-        "name": "openTradeMarketTimeout",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "pause",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "registry",
-        "outputs": [
-            {
-                "internalType": "contract IOstiumRegistry",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            },
-            {
-                "internalType": "uint256",
-                "name": "removeAmount",
-                "type": "uint256"
-            }
-        ],
-        "name": "removeCollateral",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "removeDelegate",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "delegate",
-                "type": "address"
-            }
-        ],
-        "name": "setDelegate",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "setMarketOrdersTimeout",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "setMaxAllowedCollateral",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "setTriggerTimeout",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            },
-            {
-                "internalType": "uint256",
-                "name": "topUpAmount",
-                "type": "uint256"
-            }
-        ],
-        "name": "topUpCollateral",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "triggerTimeout",
-        "outputs": [
-            {
-                "internalType": "uint16",
-                "name": "",
-                "type": "uint16"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            },
-            {
-                "internalType": "uint192",
-                "name": "price",
-                "type": "uint192"
-            },
-            {
-                "internalType": "uint192",
-                "name": "tp",
-                "type": "uint192"
-            },
-            {
-                "internalType": "uint192",
-                "name": "sl",
-                "type": "uint192"
-            }
-        ],
-        "name": "updateOpenLimitOrder",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            },
-            {
-                "internalType": "uint192",
-                "name": "newSl",
-                "type": "uint192"
-            }
-        ],
-        "name": "updateSl",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint16",
-                "name": "pairIndex",
-                "type": "uint16"
-            },
-            {
-                "internalType": "uint8",
-                "name": "index",
-                "type": "uint8"
-            },
-            {
-                "internalType": "uint192",
-                "name": "newTp",
-                "type": "uint192"
-            }
-        ],
-        "name": "updateTp",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }
-]
+        {
+            "inputs": [],
+            "stateMutability": "nonpayable",
+            "type": "constructor"
+        },
+        {
+            "inputs": [],
+            "name": "AboveMaxAllowedCollateral",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                }
+            ],
+            "name": "AlreadyMarketClosed",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "BelowFees",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "BelowMinLevPos",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "DelegateForbidden",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "DelegateReentrant",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "DelegatedActionFailed",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "ExposureLimits",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidCallData",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidInitialization",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidNonce",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidSignature",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "a",
+                    "type": "address"
+                }
+            ],
+            "name": "IsContract",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "IsDone",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "IsPaused",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                }
+            ],
+            "name": "MaxPendingMarketOrdersReached",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                }
+            ],
+            "name": "MaxTradesPerPairReached",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "a",
+                    "type": "address"
+                }
+            ],
+            "name": "NoDelegate",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                }
+            ],
+            "name": "NoLimitFound",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                }
+            ],
+            "name": "NoTradeFound",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NoTradeToTimeoutFound",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NotCloseMarketTimeoutOrder",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "caller",
+                    "type": "address"
+                }
+            ],
+            "name": "NotDelegate",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "a",
+                    "type": "address"
+                }
+            ],
+            "name": "NotGov",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "NotInitializing",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "a",
+                    "type": "address"
+                }
+            ],
+            "name": "NotManager",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "NotOpenMarketTimeoutOrder",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "a",
+                    "type": "address"
+                }
+            ],
+            "name": "NotTradesUpKeep",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                }
+            ],
+            "name": "NotYourOrder",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "NullAddr",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "index",
+                    "type": "uint16"
+                }
+            ],
+            "name": "PairNotListed",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint8",
+                    "name": "bits",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "SafeCastOverflowedUintDowncast",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "SignatureExpired",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                }
+            ],
+            "name": "TriggerPending",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                }
+            ],
+            "name": "WaitTimeout",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "leverage",
+                    "type": "uint32"
+                }
+            ],
+            "name": "WrongLeverage",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "WrongParams",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "WrongSL",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "WrongTP",
+            "type": "error"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "enum IOstiumTradingStorage.LimitOrder",
+                    "name": "",
+                    "type": "uint8"
+                }
+            ],
+            "name": "AutomationCloseOrderInitiated",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                }
+            ],
+            "name": "AutomationOpenOrderInitiated",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "delegator",
+                    "type": "address"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "delegate",
+                    "type": "address"
+                }
+            ],
+            "name": "DelegateAdded",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "delegator",
+                    "type": "address"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "delegate",
+                    "type": "address"
+                }
+            ],
+            "name": "DelegateRemoved",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": False,
+                    "internalType": "bool",
+                    "name": "done",
+                    "type": "bool"
+                }
+            ],
+            "name": "Done",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": False,
+                    "internalType": "uint64",
+                    "name": "version",
+                    "type": "uint64"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                }
+            ],
+            "name": "MarketCloseFailed",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                }
+            ],
+            "name": "MarketCloseOrderInitiated",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint16",
+                    "name": "closePercentage",
+                    "type": "uint16"
+                }
+            ],
+            "name": "MarketCloseOrderInitiatedV2",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "block",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint192",
+                            "name": "wantedPrice",
+                            "type": "uint192"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "slippageP",
+                            "type": "uint32"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "collateral",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint192",
+                                    "name": "openPrice",
+                                    "type": "uint192"
+                                },
+                                {
+                                    "internalType": "uint192",
+                                    "name": "tp",
+                                    "type": "uint192"
+                                },
+                                {
+                                    "internalType": "uint192",
+                                    "name": "sl",
+                                    "type": "uint192"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint32",
+                                    "name": "leverage",
+                                    "type": "uint32"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "pairIndex",
+                                    "type": "uint16"
+                                },
+                                {
+                                    "internalType": "uint8",
+                                    "name": "index",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "bool",
+                                    "name": "buy",
+                                    "type": "bool"
+                                },
+                                {
+                                    "internalType": "bool",
+                                    "name": "isDayTrade",
+                                    "type": "bool"
+                                }
+                            ],
+                            "internalType": "struct IOstiumTradingStorage.Trade",
+                            "name": "trade",
+                            "type": "tuple"
+                        }
+                    ],
+                    "indexed": False,
+                    "internalType": "struct IOstiumTradingStorage.PendingMarketOrder",
+                    "name": "order",
+                    "type": "tuple"
+                }
+            ],
+            "name": "MarketCloseTimeoutExecuted",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "block",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint192",
+                            "name": "wantedPrice",
+                            "type": "uint192"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "slippageP",
+                            "type": "uint32"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "collateral",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint192",
+                                    "name": "openPrice",
+                                    "type": "uint192"
+                                },
+                                {
+                                    "internalType": "uint192",
+                                    "name": "tp",
+                                    "type": "uint192"
+                                },
+                                {
+                                    "internalType": "uint192",
+                                    "name": "sl",
+                                    "type": "uint192"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint32",
+                                    "name": "leverage",
+                                    "type": "uint32"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "pairIndex",
+                                    "type": "uint16"
+                                },
+                                {
+                                    "internalType": "uint8",
+                                    "name": "index",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "bool",
+                                    "name": "buy",
+                                    "type": "bool"
+                                },
+                                {
+                                    "internalType": "bool",
+                                    "name": "isDayTrade",
+                                    "type": "bool"
+                                }
+                            ],
+                            "internalType": "struct IOstiumTradingStorage.Trade",
+                            "name": "trade",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "uint16",
+                            "name": "percentage",
+                            "type": "uint16"
+                        }
+                    ],
+                    "indexed": False,
+                    "internalType": "struct IOstiumTradingStorage.PendingMarketOrderV2",
+                    "name": "order",
+                    "type": "tuple"
+                }
+            ],
+            "name": "MarketCloseTimeoutExecutedV2",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                }
+            ],
+            "name": "MarketOpenOrderInitiated",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "block",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint192",
+                            "name": "wantedPrice",
+                            "type": "uint192"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "slippageP",
+                            "type": "uint32"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "collateral",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint192",
+                                    "name": "openPrice",
+                                    "type": "uint192"
+                                },
+                                {
+                                    "internalType": "uint192",
+                                    "name": "tp",
+                                    "type": "uint192"
+                                },
+                                {
+                                    "internalType": "uint192",
+                                    "name": "sl",
+                                    "type": "uint192"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint32",
+                                    "name": "leverage",
+                                    "type": "uint32"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "pairIndex",
+                                    "type": "uint16"
+                                },
+                                {
+                                    "internalType": "uint8",
+                                    "name": "index",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "bool",
+                                    "name": "buy",
+                                    "type": "bool"
+                                },
+                                {
+                                    "internalType": "bool",
+                                    "name": "isDayTrade",
+                                    "type": "bool"
+                                }
+                            ],
+                            "internalType": "struct IOstiumTradingStorage.Trade",
+                            "name": "trade",
+                            "type": "tuple"
+                        }
+                    ],
+                    "indexed": False,
+                    "internalType": "struct IOstiumTradingStorage.PendingMarketOrder",
+                    "name": "order",
+                    "type": "tuple"
+                }
+            ],
+            "name": "MarketOpenTimeoutExecuted",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "block",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint192",
+                            "name": "wantedPrice",
+                            "type": "uint192"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "slippageP",
+                            "type": "uint32"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint256",
+                                    "name": "collateral",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint192",
+                                    "name": "openPrice",
+                                    "type": "uint192"
+                                },
+                                {
+                                    "internalType": "uint192",
+                                    "name": "tp",
+                                    "type": "uint192"
+                                },
+                                {
+                                    "internalType": "uint192",
+                                    "name": "sl",
+                                    "type": "uint192"
+                                },
+                                {
+                                    "internalType": "address",
+                                    "name": "trader",
+                                    "type": "address"
+                                },
+                                {
+                                    "internalType": "uint32",
+                                    "name": "leverage",
+                                    "type": "uint32"
+                                },
+                                {
+                                    "internalType": "uint16",
+                                    "name": "pairIndex",
+                                    "type": "uint16"
+                                },
+                                {
+                                    "internalType": "uint8",
+                                    "name": "index",
+                                    "type": "uint8"
+                                },
+                                {
+                                    "internalType": "bool",
+                                    "name": "buy",
+                                    "type": "bool"
+                                },
+                                {
+                                    "internalType": "bool",
+                                    "name": "isDayTrade",
+                                    "type": "bool"
+                                }
+                            ],
+                            "internalType": "struct IOstiumTradingStorage.Trade",
+                            "name": "trade",
+                            "type": "tuple"
+                        },
+                        {
+                            "internalType": "uint16",
+                            "name": "percentage",
+                            "type": "uint16"
+                        }
+                    ],
+                    "indexed": False,
+                    "internalType": "struct IOstiumTradingStorage.PendingMarketOrderV2",
+                    "name": "order",
+                    "type": "tuple"
+                }
+            ],
+            "name": "MarketOpenTimeoutExecutedV2",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": False,
+                    "internalType": "uint16",
+                    "name": "value",
+                    "type": "uint16"
+                }
+            ],
+            "name": "MarketOrdersTimeoutUpdated",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": False,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MaxAllowedCollateralUpdated",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                }
+            ],
+            "name": "OpenLimitCanceled",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                }
+            ],
+            "name": "OpenLimitPlaced",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "collateral",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint192",
+                            "name": "openPrice",
+                            "type": "uint192"
+                        },
+                        {
+                            "internalType": "uint192",
+                            "name": "tp",
+                            "type": "uint192"
+                        },
+                        {
+                            "internalType": "uint192",
+                            "name": "sl",
+                            "type": "uint192"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "trader",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "leverage",
+                            "type": "uint32"
+                        },
+                        {
+                            "internalType": "uint16",
+                            "name": "pairIndex",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "index",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "buy",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "isDayTrade",
+                            "type": "bool"
+                        }
+                    ],
+                    "indexed": False,
+                    "internalType": "struct IOstiumTradingStorage.Trade",
+                    "name": "trade",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "enum IOstiumTradingStorage.OpenOrderType",
+                    "name": "orderType",
+                    "type": "uint8"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "builder",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "builderFee",
+                            "type": "uint32"
+                        }
+                    ],
+                    "indexed": False,
+                    "internalType": "struct IOstiumTradingStorage.BuilderFee",
+                    "name": "builderFee",
+                    "type": "tuple"
+                }
+            ],
+            "name": "OpenLimitPlacedV2",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint192",
+                    "name": "newPrice",
+                    "type": "uint192"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint192",
+                    "name": "newTp",
+                    "type": "uint192"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint192",
+                    "name": "newSl",
+                    "type": "uint192"
+                }
+            ],
+            "name": "OpenLimitUpdated",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "OracleFeeCharged",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "OracleFeeChargedLimitCancelled",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "OracleFeeRefunded",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": False,
+                    "internalType": "bool",
+                    "name": "paused",
+                    "type": "bool"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint256",
+                    "name": "removeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RemoveCollateralInitiated",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "orderId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint256",
+                    "name": "removeAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "string",
+                    "name": "reason",
+                    "type": "string"
+                }
+            ],
+            "name": "RemoveCollateralRejected",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint192",
+                    "name": "newSl",
+                    "type": "uint192"
+                }
+            ],
+            "name": "SlUpdated",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint256",
+                    "name": "topUpAmount",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint32",
+                    "name": "newLeverage",
+                    "type": "uint32"
+                }
+            ],
+            "name": "TopUpCollateralExecuted",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": True,
+                    "internalType": "uint256",
+                    "name": "tradeId",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "indexed": True,
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": False,
+                    "internalType": "uint192",
+                    "name": "newTp",
+                    "type": "uint192"
+                }
+            ],
+            "name": "TpUpdated",
+            "type": "event"
+        },
+        {
+            "anonymous": False,
+            "inputs": [
+                {
+                    "indexed": False,
+                    "internalType": "uint16",
+                    "name": "value",
+                    "type": "uint16"
+                }
+            ],
+            "name": "TriggerTimeoutUpdated",
+            "type": "event"
+        },
+        {
+            "inputs": [],
+            "name": "DELEGATION_TYPEHASH",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "DOMAIN_SEPARATOR",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "_msgSender",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                }
+            ],
+            "name": "cancelOpenLimitOrder",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint16",
+                    "name": "closePercentage",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint192",
+                    "name": "marketPrice",
+                    "type": "uint192"
+                },
+                {
+                    "internalType": "uint32",
+                    "name": "slippageP",
+                    "type": "uint32"
+                }
+            ],
+            "name": "closeTradeMarket",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_order",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bool",
+                    "name": "retry",
+                    "type": "bool"
+                }
+            ],
+            "name": "closeTradeMarketTimeout",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "delegatableNonces",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "call_data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "delegatedAction",
+            "outputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "",
+                    "type": "bytes"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "delegator",
+                    "type": "address"
+                }
+            ],
+            "name": "delegations",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "done",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "enum IOstiumTradingStorage.LimitOrder",
+                    "name": "orderType",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "address",
+                    "name": "trader",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "priceTimestamp",
+                    "type": "uint256"
+                }
+            ],
+            "name": "executeAutomationOrder",
+            "outputs": [
+                {
+                    "internalType": "enum IOstiumTrading.AutomationOrderStatus",
+                    "name": "",
+                    "type": "uint8"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "contract IOstiumRegistry",
+                    "name": "_registry",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_maxAllowedCollateral",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint16",
+                    "name": "_marketOrdersTimeout",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint16",
+                    "name": "_triggerTimeout",
+                    "type": "uint16"
+                }
+            ],
+            "name": "initialize",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "isDone",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "isPaused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "marketOrdersTimeout",
+            "outputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "",
+                    "type": "uint16"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "maxAllowedCollateral",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "collateral",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint192",
+                            "name": "openPrice",
+                            "type": "uint192"
+                        },
+                        {
+                            "internalType": "uint192",
+                            "name": "tp",
+                            "type": "uint192"
+                        },
+                        {
+                            "internalType": "uint192",
+                            "name": "sl",
+                            "type": "uint192"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "trader",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "leverage",
+                            "type": "uint32"
+                        },
+                        {
+                            "internalType": "uint16",
+                            "name": "pairIndex",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "uint8",
+                            "name": "index",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "buy",
+                            "type": "bool"
+                        },
+                        {
+                            "internalType": "bool",
+                            "name": "isDayTrade",
+                            "type": "bool"
+                        }
+                    ],
+                    "internalType": "struct IOstiumTradingStorage.Trade",
+                    "name": "t",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "builder",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "builderFee",
+                            "type": "uint32"
+                        }
+                    ],
+                    "internalType": "struct IOstiumTradingStorage.BuilderFee",
+                    "name": "bf",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "enum IOstiumTradingStorage.OpenOrderType",
+                    "name": "orderType",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "slippageP",
+                    "type": "uint256"
+                }
+            ],
+            "name": "openTrade",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_order",
+                    "type": "uint256"
+                }
+            ],
+            "name": "openTradeMarketTimeout",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "pause",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "registry",
+            "outputs": [
+                {
+                    "internalType": "contract IOstiumRegistry",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "removeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "removeCollateral",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "removeDelegate",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "delegate",
+                    "type": "address"
+                }
+            ],
+            "name": "setDelegate",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "delegator",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "delegate",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "expiry",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "v",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "r",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "s",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "setDelegateWithSignature",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "setMarketOrdersTimeout",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "setMaxAllowedCollateral",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "setTriggerTimeout",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "topUpAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "topUpCollateral",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "triggerTimeout",
+            "outputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "",
+                    "type": "uint16"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint192",
+                    "name": "price",
+                    "type": "uint192"
+                },
+                {
+                    "internalType": "uint192",
+                    "name": "tp",
+                    "type": "uint192"
+                },
+                {
+                    "internalType": "uint192",
+                    "name": "sl",
+                    "type": "uint192"
+                }
+            ],
+            "name": "updateOpenLimitOrder",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint192",
+                    "name": "newSl",
+                    "type": "uint192"
+                }
+            ],
+            "name": "updateSl",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "pairIndex",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "index",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "uint192",
+                    "name": "newTp",
+                    "type": "uint192"
+                }
+            ],
+            "name": "updateTp",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        }
+    ]

--- a/ostium_python_sdk/config.py
+++ b/ostium_python_sdk/config.py
@@ -17,7 +17,7 @@ class NetworkConfig:
     @classmethod
     def mainnet(cls) -> 'NetworkConfig':
         return cls(
-            graph_url="https://subgraph.satsuma-prod.com/391a61815d32/ostium/ost-prod/api",
+            graph_url="https://api.goldsky.com/api/public/project_cmgql529ykrlw01v6b9so0woq/subgraphs/ost-prod/v8/gn",
             contracts={
                 "usdc": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
                 "trading": "0x6D0bA1f9996DBD8885827e1b2e8f6593e7702411",
@@ -29,7 +29,7 @@ class NetworkConfig:
     @classmethod
     def testnet(cls) -> 'NetworkConfig':
         return cls(
-            graph_url="https://subgraph.satsuma-prod.com/391a61815d32/ostium/ost-sep-final/api",
+            graph_url="https://api.goldsky.com/api/public/project_cmgql529ykrlw01v6b9so0woq/subgraphs/ost-sep-final/v2/gn",
             contracts={
                 "usdc": "0xe73B11Fb1e3eeEe8AF2a23079A4410Fe1B370548",
                 "trading": "0x2A9B9c988393f46a2537B0ff11E98c2C15a95afe",

--- a/ostium_python_sdk/config.py
+++ b/ostium_python_sdk/config.py
@@ -17,7 +17,7 @@ class NetworkConfig:
     @classmethod
     def mainnet(cls) -> 'NetworkConfig':
         return cls(
-            graph_url="https://api.goldsky.com/api/public/project_cmgql529ykrlw01v6b9so0woq/subgraphs/ost-prod/v8/gn",
+            graph_url="https://api.subgraph.ormilabs.com/api/public/67a599d5-c8d2-4cc4-9c4d-2975a97bc5d8/subgraphs/ost-prod/live/gn",
             contracts={
                 "usdc": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
                 "trading": "0x6D0bA1f9996DBD8885827e1b2e8f6593e7702411",
@@ -29,7 +29,7 @@ class NetworkConfig:
     @classmethod
     def testnet(cls) -> 'NetworkConfig':
         return cls(
-            graph_url="https://api.goldsky.com/api/public/project_cmgql529ykrlw01v6b9so0woq/subgraphs/ost-sep-final/v2/gn",
+            graph_url="https://api.subgraph.ormilabs.com/api/public/67a599d5-c8d2-4cc4-9c4d-2975a97bc5d8/subgraphs/ost-sep/live/gn",
             contracts={
                 "usdc": "0xe73B11Fb1e3eeEe8AF2a23079A4410Fe1B370548",
                 "trading": "0x2A9B9c988393f46a2537B0ff11E98c2C15a95afe",

--- a/ostium_python_sdk/ostium.py
+++ b/ostium_python_sdk/ostium.py
@@ -195,17 +195,14 @@ class Ostium:
             # self.log(f"Order Receipt: {trade_receipt}")
 
             # Extract orderId from logs
+            # Contract emits MarketOpenOrderInitiated(orderId, trader, pairIndex) — all indexed
             order_id = None
+            market_open_signature = self.web3.keccak(
+                text="MarketOpenOrderInitiated(uint256,address,uint16)").hex()
             for log in trade_receipt.logs:
-                # Define PriceRequested event signature
-                price_requested_signature = self.web3.keccak(
-                    text="PriceRequested(uint256,bytes32,uint256)").hex()
-
-                # Look at the event topic to identify the event type
-                if len(log['topics']) > 0 and log['topics'][0].hex() == price_requested_signature:
-                    # orderId is the indexed parameter (second topic)
+                if len(log['topics']) > 0 and log['topics'][0].hex() == market_open_signature:
                     order_id = int(log['topics'][1].hex(), 16)
-                    self.log(f"Found orderId from PriceRequested: {order_id}")
+                    self.log(f"Found orderId from MarketOpenOrderInitiated: {order_id}")
                     break
 
             return {
@@ -332,17 +329,14 @@ class Ostium:
         # self.log(f"Trade Receipt: {trade_receipt}")
 
         # Extract orderId from logs
+        # Contract emits MarketCloseOrderInitiated(orderId, tradeId, trader, pairIndex) — all indexed
         order_id = None
+        market_close_signature = self.web3.keccak(
+            text="MarketCloseOrderInitiated(uint256,uint256,address,uint16)").hex()
         for log in trade_receipt.logs:
-            # Define PriceRequested event signature
-            price_requested_signature = self.web3.keccak(
-                text="PriceRequested(uint256,bytes32,uint256)").hex()
-
-            # Look at the event topic to identify the event type
-            if len(log['topics']) > 0 and log['topics'][0].hex() == price_requested_signature:
-                # orderId is the indexed parameter (second topic)
+            if len(log['topics']) > 0 and log['topics'][0].hex() == market_close_signature:
                 order_id = int(log['topics'][1].hex(), 16)
-                self.log(f"Found orderId from PriceRequested: {order_id}")
+                self.log(f"Found orderId from MarketCloseOrderInitiated: {order_id}")
                 break
 
         return {

--- a/ostium_python_sdk/ostium.py
+++ b/ostium_python_sdk/ostium.py
@@ -115,7 +115,8 @@ class Ostium:
                 'leverage': to_base_units(trade_params['leverage'], decimals=2),
                 'pairIndex': int(trade_params['asset_type']),
                 'index': 0,
-                'buy': trade_params['direction']
+                'buy': trade_params['direction'],
+                'isDayTrade': trade_params.get('is_day_trade', False)
             }
 
             order_type = OpenOrderType.MARKET.value
@@ -130,7 +131,11 @@ class Ostium:
                 else:
                     raise Exception('Invalid order type')
 
-            slippage = int(self.slippage_percentage * PRECISION_2)
+            # Slippage only applies to market orders; limit/stop orders must use 0
+            if order_type == OpenOrderType.MARKET.value:
+                slippage = int(self.slippage_percentage * PRECISION_2)
+            else:
+                slippage = 0
             
             # Create BuilderFee struct with default values (zero address and zero fee)
             # Can be customized if builder fees are needed in the future

--- a/ostium_python_sdk/subgraph.py
+++ b/ostium_python_sdk/subgraph.py
@@ -440,3 +440,75 @@ class SubgraphClient:
         if result and 'trades' in result and len(result['trades']) > 0:
             return result['trades'][0]
         return None
+
+    async def get_closed_trade_by_trade_id(self, trade_id):
+        """
+        Get closed orders for a specific trade ID (orderAction: "Close" and isCancelled: false)
+        """
+        query = gql(
+            """
+            query GetClosedTradeByTradeID($trade_id: String!) {
+              orders(
+                where: {tradeID: $trade_id, orderAction: "Close", isCancelled: false}
+                orderBy: executedAt
+                orderDirection: desc
+              ) {
+                id
+                isBuy
+                profitPercent
+                tradeID
+                trader
+                isCancelled
+                closePercent
+                executedAt
+                orderAction
+                cancelReason
+                price
+                tradeNotional
+                executedTx
+              }
+            }
+            """
+        )
+
+        result = await self._execute_query(query, variable_values={"trade_id": str(trade_id)})
+
+        if result and 'orders' in result:
+            return result['orders']
+        return []
+
+    async def get_cancelled_orders_by_trade_id(self, trade_id):
+        """
+        Get cancelled orders for a specific trade ID (isCancelled: true)
+        """
+        query = gql(
+            """
+            query GetCancelledOrderByTradeID($trade_id: String!) {
+              orders(
+                where: {tradeID: $trade_id, isCancelled: true}
+                orderBy: executedAt
+                orderDirection: desc
+              ) {
+                id
+                isBuy
+                profitPercent
+                tradeID
+                trader
+                isCancelled
+                closePercent
+                executedAt
+                orderAction
+                cancelReason
+                price
+                tradeNotional
+                executedTx
+              }
+            }
+            """
+        )
+
+        result = await self._execute_query(query, variable_values={"trade_id": str(trade_id)})
+
+        if result and 'orders' in result:
+            return result['orders']
+        return []

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ if changelog_path.exists():
     long_description += "\n\n" + changelog_path.read_text()
 
 setup(
-    name="ostium-python-sdk",
-    version="3.0.0",
+    name="ostium-python-sdk-test",
+    version="3.0.1.1",
     packages=find_packages(),
     install_requires=read_requirements('requirements.txt'),
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if changelog_path.exists():
 
 setup(
     name="ostium-python-sdk-test",
-    version="3.0.1.1",
+    version="3.0.1.4",
     packages=find_packages(),
     install_requires=read_requirements('requirements.txt'),
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if changelog_path.exists():
 
 setup(
     name="ostium-python-sdk-test",
-    version="3.0.1.5",
+    version="3.0.1.6",
     packages=find_packages(),
     install_requires=read_requirements('requirements.txt'),
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if changelog_path.exists():
 
 setup(
     name="ostium-python-sdk-test",
-    version="3.0.1.4",
+    version="3.0.1.5",
     packages=find_packages(),
     install_requires=read_requirements('requirements.txt'),
     extras_require={


### PR DESCRIPTION
## Summary

Adds two new methods to the `SubgraphClient` class to retrieve order history by trade ID:
- `get_closed_trade_by_trade_id()`: Retrieves successfully closed orders for a specific trade
- `get_cancelled_orders_by_trade_id()`: Retrieves cancelled orders for a specific trade

## Changes

This PR introduces the following functionality:

### `get_closed_trade_by_trade_id(trade_id)`
- Retrieves all closed orders for a given trade ID
- Filters by `orderAction: "Close"` and `isCancelled: false`
- Returns orders sorted by execution time (most recent first)
- Useful for tracking trade completion history

### `get_cancelled_orders_by_trade_id(trade_id)`
- Retrieves all cancelled orders for a given trade ID
- Filters by `isCancelled: true`
- Returns orders sorted by execution time (most recent first)
- Useful for debugging and understanding failed/partial fills

## Use Cases

These methods enable:
- Better trade history analysis
- Tracking order lifecycle from opening to closing
- Debugging partially filled or cancelled trades