### PR TITLE
Hardcode slippage to 0 for limit/stop orders, update subgraph URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Ostium Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-02-14
+
+### Breaking Changes
+- **Limit and Stop orders now enforce slippage = 0** per contract upgrade. Slippage is no longer configurable for LIMIT/STOP order types and is hardcoded to 0. Market orders are unaffected.
+
+### Changed
+- Migrated subgraph URLs to new Ormi Labs hosted endpoints for both mainnet and testnet
+- `perform_trade()` now sets slippage to 0 for LIMIT and STOP orders regardless of `set_slippage_percentage()` value
+
 ## [3.0.0] - 2025-10-15
 
 ### Breaking Changes

--- a/ostium_python_sdk/config.py
+++ b/ostium_python_sdk/config.py
@@ -17,7 +17,7 @@ class NetworkConfig:
     @classmethod
     def mainnet(cls) -> 'NetworkConfig':
         return cls(
-            graph_url="https://subgraph.satsuma-prod.com/391a61815d32/ostium/ost-prod/api",
+            graph_url="https://api.subgraph.ormilabs.com/api/public/67a599d5-c8d2-4cc4-9c4d-2975a97bc5d8/subgraphs/ost-prod/live/gn",
             contracts={
                 "usdc": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
                 "trading": "0x6D0bA1f9996DBD8885827e1b2e8f6593e7702411",
@@ -29,7 +29,7 @@ class NetworkConfig:
     @classmethod
     def testnet(cls) -> 'NetworkConfig':
         return cls(
-            graph_url="https://subgraph.satsuma-prod.com/391a61815d32/ostium/ost-sep-final/api",
+            graph_url="https://api.subgraph.ormilabs.com/api/public/67a599d5-c8d2-4cc4-9c4d-2975a97bc5d8/subgraphs/ost-sep/live/gn",
             contracts={
                 "usdc": "0xe73B11Fb1e3eeEe8AF2a23079A4410Fe1B370548",
                 "trading": "0x2A9B9c988393f46a2537B0ff11E98c2C15a95afe",

--- a/ostium_python_sdk/ostium.py
+++ b/ostium_python_sdk/ostium.py
@@ -130,8 +130,12 @@ class Ostium:
                 else:
                     raise Exception('Invalid order type')
 
-            slippage = int(self.slippage_percentage * PRECISION_2)
-            
+            # Slippage only applies to market orders; limit/stop orders must use 0
+            if order_type == OpenOrderType.MARKET.value:
+                slippage = int(self.slippage_percentage * PRECISION_2)
+            else:
+                slippage = 0
+
             # Create BuilderFee struct with default values (zero address and zero fee)
             # Can be customized if builder fees are needed in the future
             builder_fee = {

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if changelog_path.exists():
 
 setup(
     name="ostium-python-sdk",
-    version="3.0.0",
+    version="3.1.0",
     packages=find_packages(),
     install_requires=read_requirements('requirements.txt'),
     extras_require={


### PR DESCRIPTION
Breaking contract change requires slippage=0 for LIMIT/STOP orders. Migrate subgraph endpoints to Ormi Labs. Bump to v3.1.0.