### PR TITLE
Fix: extract orderId from MarketOpenOrderInitiated / MarketCloseOrderInitiated events

### DIFF
--- a/ostium_python_sdk/ostium.py
+++ b/ostium_python_sdk/ostium.py
@@ -195,17 +195,15 @@ class Ostium:
             # self.log(f"Order Receipt: {trade_receipt}")
 
             # Extract orderId from logs
+            # Contract emits MarketOpenOrderInitiated(orderId, trader, pairIndex) — all indexed
             order_id = None
+            market_open_signature = self.web3.keccak(
+                text="MarketOpenOrderInitiated(uint256,address,uint16)").hex()
             for log in trade_receipt.logs:
-                # Define PriceRequested event signature
-                price_requested_signature = self.web3.keccak(
-                    text="PriceRequested(uint256,bytes32,uint256)").hex()
-
-                # Look at the event topic to identify the event type
-                if len(log['topics']) > 0 and log['topics'][0].hex() == price_requested_signature:
-                    # orderId is the indexed parameter (second topic)
+                if len(log['topics']) > 0 and log['topics'][0].hex() == market_open_signature:
+                    # orderId is the first indexed parameter (second topic)
                     order_id = int(log['topics'][1].hex(), 16)
-                    self.log(f"Found orderId from PriceRequested: {order_id}")
+                    self.log(f"Found orderId from MarketOpenOrderInitiated: {order_id}")
                     break
 
             return {
@@ -332,17 +330,15 @@ class Ostium:
         # self.log(f"Trade Receipt: {trade_receipt}")
 
         # Extract orderId from logs
+        # Contract emits MarketCloseOrderInitiated(orderId, tradeId, trader, pairIndex) — all indexed
         order_id = None
+        market_close_signature = self.web3.keccak(
+            text="MarketCloseOrderInitiated(uint256,uint256,address,uint16)").hex()
         for log in trade_receipt.logs:
-            # Define PriceRequested event signature
-            price_requested_signature = self.web3.keccak(
-                text="PriceRequested(uint256,bytes32,uint256)").hex()
-
-            # Look at the event topic to identify the event type
-            if len(log['topics']) > 0 and log['topics'][0].hex() == price_requested_signature:
-                # orderId is the indexed parameter (second topic)
+            if len(log['topics']) > 0 and log['topics'][0].hex() == market_close_signature:
+                # orderId is the first indexed parameter (second topic)
                 order_id = int(log['topics'][1].hex(), 16)
-                self.log(f"Found orderId from PriceRequested: {order_id}")
+                self.log(f"Found orderId from MarketCloseOrderInitiated: {order_id}")
                 break
 
         return {


### PR DESCRIPTION
## Summary

After the recent Ostium trading contract upgrade, the SDK no longer returns `order_id` from `perform_trade()` and `close_trade()`. Both methods scanned transaction receipt logs for `PriceRequested(uint256,bytes32,uint256)`, but the upgraded contract no longer emits that event so `order_id` always stayed `None` even when the trade succeeded on-chain.

The contract now emits two distinct events instead:
- **Opens:** `MarketOpenOrderInitiated(uint256 orderId, address trader, uint16 pairIndex)` 
- **Closes:** `MarketCloseOrderInitiated(uint256 orderId, uint256 tradeId, address trader, uint16 pairIndex)` 

In both cases, `orderId` is the first indexed parameter (`topics[1]`), so the parsing logic stays nearly identical, only the event signature being hashed needs to change.

## Changes

- `ostium_python_sdk/ostium.py`
  - `perform_trade()`: scan for `MarketOpenOrderInitiated` instead of `PriceRequested`
  - `close_trade()`: scan for `MarketCloseOrderInitiated` instead of `PriceRequested`
  - Hoisted the `keccak()` call out of the per-log loop (was being recomputed on every log iteration)
  - Updated log messages to reference the new event names