### PR TITLE
Migrate price feed endpoint to bedrock (v3.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Ostium Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2026-07-21
+
+### Changed
+- Migrated price feed endpoint to `metadata-backend.prod.bedrock.ostium.io`
+
 ## [3.3.0] - 2026-07-09
 
 ### Performance

--- a/examples/example-test-price-endpoint.py
+++ b/examples/example-test-price-endpoint.py
@@ -1,0 +1,20 @@
+import asyncio
+from ostium_python_sdk.price import Price
+
+
+async def main():
+    price = Price(verbose=True)
+    print(f"Endpoint: {price.base_url}")
+
+    prices = await price.get_latest_prices()
+    assert isinstance(prices, list) and len(prices) > 0, "no prices returned"
+    print(f"OK: fetched {len(prices)} feeds")
+
+    btc = await price.get_latest_price_json("BTC", "USD")
+    assert btc.get("mid"), "BTC/USD missing mid price"
+    mid, is_open, is_day_closed = await price.get_price("BTC", "USD")
+    print(f"BTC/USD mid={mid:,.2f} open={is_open} dayClosed={is_day_closed}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ostium_python_sdk/price.py
+++ b/ostium_python_sdk/price.py
@@ -6,7 +6,7 @@ from typing import Tuple
 class Price:
     def __init__(self, verbose=False):
         self.verbose = verbose
-        self.base_url = "https://metadata-backend.ostium.io"
+        self.base_url = "https://metadata-backend.prod.bedrock.ostium.io"
 
     def log(self, message):
         if self.verbose:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if changelog_path.exists():
 
 setup(
     name="ostium-python-sdk",
-    version="3.3.0",
+    version="3.3.1",
     packages=find_packages(),
     install_requires=read_requirements('requirements.txt'),
     extras_require={


### PR DESCRIPTION
Migrates the price feed endpoint from `metadata-backend.ostium.io` to
`metadata-backend.prod.bedrock.ostium.io`. Bumps version to 3.3.1.

## Why
Price feeds now served from the bedrock production backend.

## Changes
- `ostium_python_sdk/price.py` — updated `base_url`
- `setup.py` — version 3.3.0 → 3.3.1
- `CHANGELOG.md` — 3.3.1 entry
- `examples/example-test-price-endpoint.py` — smoke test for the endpoint

## Testing
Ran `examples/example-test-price-endpoint.py` against the new endpoint:
- Fetched 87 price feeds
- BTC/USD resolved: mid=66,404.98, market open